### PR TITLE
Add admin addon.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ COPY --chown=1001:0 . .
 RUN make cmd
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+USER root
 WORKDIR /working
 COPY --from=builder /opt/app-root/src/bin/addon /usr/local/bin/addon
 ENTRYPOINT ["/usr/local/bin/addon"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # tackle2-addon
 Tackle (2nd Generation) addon.
+
+Provides common addon packages for working with:
+- Git
+- Subversion
+- Maven
+- SSH credentials
+
+Admin addon provides the the following capabilities specified using
+the task _variant_:
+- Report mounted volume `Capacity` and `Used`.
+  - variant: mount:report
+- Delete content of mounted volumes.
+  - variant: mount:clean
+
+---
+
+Example tasks:
+
+mount:report
+```
+{
+   "name":"mount-report",
+   "state": "Ready",
+   "variant":"mount:report",
+   "priority": 1,
+   "addon": "admin",
+   "data": {
+   "path": "m2"
+   }
+}
+```
+
+mount:clean
+```
+{
+   "name":"mount-clean",
+   "state": "Ready",
+   "variant":"mount:clean",
+   "priority": 1,
+   "policy": "Isolated",
+   "addon": "admin",
+   "data": {
+     "path": "m2"
+   }
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ mount:clean
    "state": "Ready",
    "variant":"mount:clean",
    "priority": 1,
-   "policy": "Isolated",
+   "policy": "isolated",
    "addon": "admin",
    "data": {
      "path": "m2"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -87,6 +87,7 @@ func mountClean() (err error) {
 			return
 		}
 	}
+	err = mountReport()
 	return
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,5 +1,110 @@
-package cmd
+package main
+
+import (
+	"github.com/konveyor/tackle2-addon/command"
+	"github.com/konveyor/tackle2-addon/nas"
+	hub "github.com/konveyor/tackle2-hub/addon"
+	"os"
+	pathlib "path"
+	"strings"
+)
+
+var (
+	addon = hub.Addon
+)
+
+type SoftError = hub.SoftError
 
 func main() {
+	addon.Run(func() (err error) {
+		variant := addon.Variant()
+		addon.Activity("Variant: %s", variant)
+		switch variant {
+		case "mount:report":
+			err = mountReport()
+		case "mount:clean":
+			err = mountClean()
+		default:
+			err = &SoftError{Reason: "Variant not supported."}
+		}
+		return
+	})
+}
 
+//
+// mountReport reports mount statistics.
+func mountReport() (err error) {
+	d := &MountInput{}
+	err = addon.DataWith(d)
+	if err != nil {
+		err = &SoftError{Reason: err.Error()}
+		return
+	}
+	if len(d.Mount) == 0 {
+		err = &SoftError{Reason: "Path required."}
+		return
+	}
+	cmd := command.Command{Path: "/usr/bin/df"}
+	cmd.Options.Add("-h")
+	cmd.Options.Addf(d.path())
+	err = cmd.Run()
+	if err != nil {
+		return
+	}
+	result := MountReport{}
+	output := string(cmd.Output)
+	output = strings.Split(output, "\n")[1]
+	part := strings.Fields(output)
+	result.Capacity = part[1]
+	result.Used = part[2]
+	addon.Result(result)
+	return
+}
+
+//
+// mountClean deletes the content of the mount.
+func mountClean() (err error) {
+	d := &MountInput{}
+	err = addon.DataWith(d)
+	if err != nil {
+		err = &SoftError{Reason: err.Error()}
+		return
+	}
+	if len(d.Mount) == 0 {
+		err = &SoftError{Reason: "Mount name required."}
+		return
+	}
+	content, err := os.ReadDir(d.path())
+	if err != nil {
+		err = &SoftError{Reason: err.Error()}
+		return
+	}
+	for _, entry := range content {
+		p := pathlib.Join(d.path(), entry.Name())
+		err = nas.RmDir(p)
+		if err != nil {
+			err = &SoftError{Reason: err.Error()}
+			return
+		}
+	}
+	return
+}
+
+//
+// MountInput data.
+type MountInput struct {
+	Mount string `json:"path"`
+}
+
+//
+// Mount path.
+func (r *MountInput) path() string {
+	return "/mnt/" + r.Mount
+}
+
+//
+// MountReport The df variant result.
+type MountReport struct {
+	Capacity string `json:"capacity,omitempty"`
+	Used     string `json:"used"`
 }

--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,5 @@ replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-
 require (
 	github.com/clbanning/mxj v1.8.4
 	github.com/konveyor/controller v0.8.0
-	github.com/konveyor/tackle2-hub v0.0.0-20220426192451-011b58e3f803
+	github.com/konveyor/tackle2-hub v0.0.0-20220504114809-65b74531abda
 )

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konveyor/controller v0.8.0 h1:TB4KOqnWKzpuW0LLI571NzQYIXI/bmcf9K1vl8ctVkg=
 github.com/konveyor/controller v0.8.0/go.mod h1:U2h8HnX1MXoUlLA8ySP+PJClK9+aR38mxtqLGAvAprE=
-github.com/konveyor/tackle2-hub v0.0.0-20220426192451-011b58e3f803 h1:ChcJDEkE+ZbKzPqCLf5GrsVFHiS+9qJVFgl/tUlD/XI=
-github.com/konveyor/tackle2-hub v0.0.0-20220426192451-011b58e3f803/go.mod h1:DwBjZy3Kk7GDFH1FgTPjUpo8oq99jdCjyAH1zkQGCzc=
+github.com/konveyor/tackle2-hub v0.0.0-20220504114809-65b74531abda h1:CrhgnOtU0Q4vZOfqzcmU6uwFQ+vDJCXPqjcxeSZo2BQ=
+github.com/konveyor/tackle2-hub v0.0.0-20220504114809-65b74531abda/go.mod h1:DwBjZy3Kk7GDFH1FgTPjUpo8oq99jdCjyAH1zkQGCzc=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/hack/addon.yml
+++ b/hack/addon.yml
@@ -2,7 +2,13 @@
 kind: Addon
 apiVersion: tackle.konveyor.io/v1alpha1
 metadata:
-  name: test
+  name: admin
 spec:
-  image: quay.io/jortel/tackle-addon
-
+  image: quay.io/jortel/tackle2-addon-admin
+  mounts:
+    - claim: tackle-windup-addon-volume-claim
+      name: m2
+  resources:
+    requests:
+      cpu: 50m
+      memory: 50Mi

--- a/repository/git.go
+++ b/repository/git.go
@@ -259,10 +259,10 @@ func (r *Git) checkout() (err error) {
 //
 // GitURL git clone URL.
 type GitURL struct {
-	Raw string
+	Raw    string
 	Scheme string
-	Host string
-	Path string
+	Host   string
+	Path   string
 }
 
 //


### PR DESCRIPTION
Adds the _admin_ addon (my rename it).
It provides _addon-related_ functionality not part of (or appropriate for) the hub.
The 2 initial functions (task variants) provided are:
- Calculate the size of the maven m2 cache volume.
- Clean (delete all) the content of the volume when it gets full or corrupted.

These functions need to be dispatched to an addon through the tasking system because:
- Requires access to volumes not mounted in the hub.
- Can be long running.
- The clean must be done when no other tasks are running.  (policy=isolated). 