### PR TITLE
Fix git proxies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.so
 *.dylib
 
+/bin/*
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,5 @@ replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-
 require (
 	github.com/clbanning/mxj v1.8.4
 	github.com/konveyor/controller v0.8.0
-	github.com/konveyor/tackle2-hub v0.0.0-20220504114809-65b74531abda
+	github.com/konveyor/tackle2-hub v0.0.0-20220510102650-542558f3f9cb
 )
-
-replace github.com/konveyor/tackle2-hub => github.com/jortel/tackle2-hub v0.0.0-20220507143131-c3e61182d4ef

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,6 @@ github.com/jinzhu/now v1.1.3/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/
 github.com/jinzhu/now v1.1.4 h1:tHnRBy1i5F2Dh8BAFxqFzxKqqvezXrL2OW1TnX+Mlas=
 github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/jortel/tackle2-hub v0.0.0-20220507143131-c3e61182d4ef h1:HymV4y6eGanOcOfLcIHpA9twvLL4kYsGdQGBhULYSzw=
-github.com/jortel/tackle2-hub v0.0.0-20220507143131-c3e61182d4ef/go.mod h1:WcxWlSwZlupU0Lp00k6MfnkDR3vkk5Ba5Nq6jmViywk=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -314,6 +312,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konveyor/controller v0.8.0 h1:TB4KOqnWKzpuW0LLI571NzQYIXI/bmcf9K1vl8ctVkg=
 github.com/konveyor/controller v0.8.0/go.mod h1:U2h8HnX1MXoUlLA8ySP+PJClK9+aR38mxtqLGAvAprE=
+github.com/konveyor/tackle2-hub v0.0.0-20220510102650-542558f3f9cb h1:HCfULK71qLct5S+7bMmnDGSI1/TTIj8BhCDP2SjEueM=
+github.com/konveyor/tackle2-hub v0.0.0-20220510102650-542558f3f9cb/go.mod h1:WcxWlSwZlupU0Lp00k6MfnkDR3vkk5Ba5Nq6jmViywk=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/repository/git.go
+++ b/repository/git.go
@@ -225,8 +225,7 @@ func (r *Git) proxy() (proxy string, err error) {
 			id.Password)
 	}
 	proxy = fmt.Sprintf(
-		"%s://%s%s",
-		p.Kind,
+		"http://%s%s",
 		auth,
 		p.Host)
 	if p.Port > 0 {


### PR DESCRIPTION
Fix git proxies to always use `http://`.

---
Unrelated:
- Removed bin/addon (binary) from git.
- Updated .gitignore to exclude `bin/*`
- Fixed go.mod which was redirected to my (jortel) github during development.

Fixes: https://issues.redhat.com/browse/TACKLE-535