### PR TITLE
Ensure SSH key formatting.

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -10,6 +10,7 @@ import (
 	"github.com/konveyor/tackle2-hub/api"
 	"os"
 	pathlib "path"
+	"strings"
 )
 
 var (
@@ -80,7 +81,7 @@ func (r *Agent) Add(id *api.Identity, host string) (err error) {
 			path)
 		return
 	}
-	_, err = f.Write([]byte(id.Key))
+	_, err = f.Write([]byte(r.format(id.Key)))
 	if err != nil {
 		err = liberr.Wrap(
 			err,
@@ -126,6 +127,15 @@ func (r *Agent) Add(id *api.Identity, host string) (err error) {
 			path)
 	}
 	_ = f.Close()
+	return
+}
+
+//
+// Ensure key formatting.
+func (r *Agent) format(in string) (out string) {
+	if in != "" {
+		out = strings.TrimSpace(in) + "\n"
+	}
 	return
 }
 


### PR DESCRIPTION
```
-----BEGIN OPENSSH PRIVATE KEY-----
b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABBTGLg1nw
FRYTZNqiJ6JxugAAAAEAAAAAEAAAIXAAAAB3NzaC1yc2EAAAADAQABAAACAQC2mTsrFWuP
NyYkDl+kj1KcbWZ1cq+hla8lSM7oEvFuk1nU4KPNB2KCcj
-----END OPENSSH PRIVATE KEY-----
```

Ensure leading white-space is stripped and footer `-----END OPENSSH PRIVATE KEY-----` is on it's own line.
This resolves an ssh lib version comparability issues.