### PR TITLE
Relax file already exists

### DIFF
--- a/nas/dir.go
+++ b/nas/dir.go
@@ -23,19 +23,7 @@ func RmDir(path string) (err error) {
 //
 // HasDir return if the path exists.
 func HasDir(path string) (found bool, err error) {
-	_, err = os.Stat(path)
-	if err == nil {
-		found = true
-		return
-	}
-	if !os.IsNotExist(err) {
-		err = liberr.Wrap(
-			err,
-			"path",
-			path)
-	} else {
-		err = nil
-	}
+	found, err = Exists(path)
 	return
 }
 
@@ -52,6 +40,25 @@ func MkDir(path string, mode os.FileMode) (err error) {
 				"path",
 				path)
 		}
+	}
+	return
+}
+
+//
+// Exists return if the path exists.
+func Exists(path string) (found bool, err error) {
+	_, err = os.Stat(path)
+	if err == nil {
+		found = true
+		return
+	}
+	if !os.IsNotExist(err) {
+		err = liberr.Wrap(
+			err,
+			"path",
+			path)
+	} else {
+		err = nil
 	}
 	return
 }

--- a/repository/git.go
+++ b/repository/git.go
@@ -131,6 +131,7 @@ func (r *Git) writeConfig() (err error) {
 			path)
 	}
 	_ = f.Close()
+	addon.Activity("[FILE] Created %s.", path)
 	return
 }
 
@@ -179,6 +180,7 @@ func (r *Git) writeCreds(id *api.Identity) (err error) {
 		}
 	}
 	_ = f.Close()
+	addon.Activity("[FILE] Created %s.", path)
 	return
 }
 

--- a/repository/git.go
+++ b/repository/git.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"errors"
 	"fmt"
 	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/tackle2-addon/command"
@@ -97,9 +96,8 @@ func (r *Git) URL() (u GitURL) {
 // writeConfig writes config file.
 func (r *Git) writeConfig() (err error) {
 	path := pathlib.Join(HomeDir, ".gitconfig")
-	_, err = os.Stat(path)
-	if !errors.Is(err, os.ErrNotExist) {
-		err = liberr.Wrap(os.ErrExist)
+	found, err := nas.Exists(path)
+	if found || err != nil {
 		return
 	}
 	f, err := os.Create(path)
@@ -143,9 +141,8 @@ func (r *Git) writeCreds(id *api.Identity) (err error) {
 		return
 	}
 	path := pathlib.Join(HomeDir, ".git-credentials")
-	_, err = os.Stat(path)
-	if !errors.Is(err, os.ErrNotExist) {
-		err = liberr.Wrap(os.ErrExist)
+	found, err := nas.Exists(path)
+	if found || err != nil {
 		return
 	}
 	f, err := os.Create(path)

--- a/repository/maven.go
+++ b/repository/maven.go
@@ -169,6 +169,7 @@ func (r *Maven) writeSettings() (path string, err error) {
 			path)
 	}
 	_ = f.Close()
+	addon.Activity("[FILE] Created %s.", path)
 	return
 }
 

--- a/repository/maven.go
+++ b/repository/maven.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"errors"
 	"github.com/clbanning/mxj"
 	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/tackle2-addon/command"
@@ -145,9 +144,8 @@ func (r *Maven) writeSettings() (path string, err error) {
 	}
 	dir, _ := os.Getwd()
 	path = pathlib.Join(dir, "settings.xml")
-	_, err = os.Stat(path)
-	if !errors.Is(err, os.ErrNotExist) {
-		err = liberr.Wrap(os.ErrExist)
+	found, err = nas.Exists(path)
+	if found || err != nil {
 		return
 	}
 	f, err := os.Create(path)

--- a/repository/subversion.go
+++ b/repository/subversion.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"errors"
 	"fmt"
 	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/tackle2-addon/command"
@@ -110,9 +109,8 @@ func (r *Subversion) writeConfig() (err error) {
 		HomeDir,
 		".subversion",
 		"servers")
-	_, err = os.Stat(path)
-	if !errors.Is(err, os.ErrNotExist) {
-		err = liberr.Wrap(os.ErrExist)
+	found, err := nas.Exists(path)
+	if found || err != nil {
 		return
 	}
 	err = nas.MkDir(pathlib.Dir(path), 0755)

--- a/repository/subversion.go
+++ b/repository/subversion.go
@@ -137,6 +137,7 @@ func (r *Subversion) writeConfig() (err error) {
 			path)
 	}
 	_ = f.Close()
+	addon.Activity("[FILE] Created %s.", path)
 	return
 }
 
@@ -217,7 +218,9 @@ func (r *Subversion) writePassword(id *api.Identity) (err error) {
 			err,
 			"path",
 			path)
+		return
 	}
+	addon.Activity("[FILE] Updated %s.", path)
 	return
 }
 

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -1,7 +1,6 @@
 package ssh
 
 import (
-	"errors"
 	"fmt"
 	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/tackle2-addon/command"
@@ -65,9 +64,8 @@ func (r *Agent) Add(id *api.Identity, host string) (err error) {
 	path := pathlib.Join(
 		SSHDir,
 		suffix)
-	_, err = os.Stat(path)
-	if !errors.Is(err, os.ErrNotExist) {
-		err = liberr.Wrap(os.ErrExist)
+	found, err := nas.Exists(path)
+	if found || err != nil {
 		return
 	}
 	f, err := os.OpenFile(

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -122,6 +122,7 @@ func (r *Agent) Add(id *api.Identity, host string) (err error) {
 			path)
 	}
 	_ = f.Close()
+	addon.Activity("[FILE] Created %s.", path)
 	return
 }
 


### PR DESCRIPTION
The file already exists check is the only as a safety to prevent **developers** from accidentally overwriting their GIT, SVN and MAVEN configuration and credentials when running addons locally. This includes SSH keys.

The fix is to detect a file already exists and no-op instead of returning an error.  This achieves the same thing but supports using/installing credentials more than once.

Report (`Activity`) when creating files.  Helpful for troubleshooting and verifying behavior.

https://issues.redhat.com/browse/TACKLE-751