### PR TITLE
[backport 2.1.2] TACKLE-828: Add command timeout; ssh-add with timeout to handle invalid passphrase

### DIFF
--- a/command/cmd.go
+++ b/command/cmd.go
@@ -5,6 +5,7 @@ executing (CLI) commands.
 package command
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	liberr "github.com/konveyor/controller/pkg/error"
@@ -33,11 +34,20 @@ type Command struct {
 // The command and output are both reported in
 // task Report.Activity.
 func (r *Command) Run() (err error) {
+	err = r.RunWith(context.TODO())
+	return
+}
+
+//
+// RunWith executes the command with context.
+// The command and output are both reported in
+// task Report.Activity.
+func (r *Command) RunWith(ctx context.Context) (err error) {
 	addon.Activity(
 		"[CMD] Running: %s %s",
 		r.Path,
 		strings.Join(r.Options, " "))
-	cmd := exec.Command(r.Path, r.Options...)
+	cmd := exec.CommandContext(ctx, r.Path, r.Options...)
 	cmd.Dir = r.Dir
 	r.Output, err = cmd.CombinedOutput()
 	if err != nil {
@@ -70,7 +80,15 @@ func (r *Command) Run() (err error) {
 // RunSilent executes the command.
 // Nothing reported in task Report.Activity.
 func (r *Command) RunSilent() (err error) {
-	cmd := exec.Command(r.Path, r.Options...)
+	err = r.RunSilentWith(context.TODO())
+	return
+}
+
+//
+// RunSilentWith executes the command with context.
+// Nothing reported in task Report.Activity.
+func (r *Command) RunSilentWith(ctx context.Context) (err error) {
+	cmd := exec.CommandContext(ctx, r.Path, r.Options...)
 	cmd.Dir = r.Dir
 	err = cmd.Run()
 	return

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"context"
 	"fmt"
 	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/tackle2-addon/command"
@@ -10,6 +11,7 @@ import (
 	"os"
 	pathlib "path"
 	"strings"
+	"time"
 )
 
 var (
@@ -91,9 +93,13 @@ func (r *Agent) Add(id *api.Identity, host string) (err error) {
 	if err != nil {
 		return
 	}
+	ctx, fn := context.WithTimeout(
+		context.TODO(),
+		time.Second)
+	defer fn()
 	cmd := command.Command{Path: "/usr/bin/ssh-add"}
 	cmd.Options.Add(path)
-	err = cmd.Run()
+	err = cmd.RunWith(ctx)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
backport: https://github.com/konveyor/tackle2-addon/pull/17