### PR TITLE
:sparkles: Detected and report better errors.

### DIFF
--- a/command/cmd.go
+++ b/command/cmd.go
@@ -141,8 +141,9 @@ type ErrorPattern struct {
 }
 
 func (r *ErrorPattern) Find(output string) (err error) {
-	if r.Regex.Match([]byte(output)) {
-		err = r.Error(output)
+	matched := r.Regex.Find([]byte(output))
+	if matched != nil {
+		err = r.Error(string(matched))
 	}
 	return
 }

--- a/command/cmd_test.go
+++ b/command/cmd_test.go
@@ -1,0 +1,49 @@
+package command
+
+import (
+	"errors"
+	"github.com/onsi/gomega"
+	"regexp"
+	"testing"
+)
+
+func TestOptions(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	filter := Mask{AuthMask}
+	options := Options{}
+	options.Add("http://almer:fudd@redhat.com")
+	s := options.String(filter)
+	g.Expect("http://###:###@redhat.com").To(gomega.Equal(s))
+}
+
+func TestFilteringInCommand(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	cmd := Command{
+		Path:   "echo",
+		Silent: true,
+	}
+	cmd.Mask = Mask{AuthMask}
+	cmd.Options.Add("SEND")
+	cmd.Options.Add("http://almer:fudd@redhat.com")
+	err := cmd.Run()
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect("SEND http://###:###@redhat.com\n").To(gomega.Equal(cmd.Output))
+}
+
+func TestErrorMap(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	output := "fatal: Authentication failed for 'https://github.com/konveyor/tackle-testapp.git/"
+	mp := ErrorMap{
+		ErrorPattern{
+			Regex: regexp.MustCompile(`Authentication failed`),
+			Error: func(s string) (e error) {
+				e = errors.New("auth")
+				return
+			},
+		},
+	}
+	err := mp.Error(nil, "Hello")
+	g.Expect(err).To(gomega.BeNil())
+	err = mp.Error(nil, output)
+	g.Expect(err).ToNot(gomega.BeNil())
+}

--- a/command/cmd_test.go
+++ b/command/cmd_test.go
@@ -37,7 +37,7 @@ func TestErrorMap(t *testing.T) {
 		ErrorPattern{
 			Regex: regexp.MustCompile(`Authentication failed`),
 			Error: func(s string) (e error) {
-				e = errors.New("auth")
+				e = errors.New(s)
 				return
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/clbanning/mxj v1.8.4
 	github.com/jortel/go-utils v0.1.1
 	github.com/konveyor/tackle2-hub v0.2.2-0.20230731153407-22bf2d68128a
+	github.com/onsi/gomega v1.27.6
 )
 
 require (
@@ -35,6 +36,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,7 @@ github.com/go-resty/resty/v2 v2.6.0 h1:joIR5PNLM2EFqqESUjCMGXrWmXNHEU9CEiK813oKY
 github.com/go-resty/resty/v2 v2.6.0/go.mod h1:PwvJS6hvaPkjtjNg9ph+VrSD92bi5Zq73w/BIH7cC3Q=
 github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
 github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/goccy/go-json v0.10.0 h1:mXKd9Qw4NuzShiRlOXKews24ufknHO7gx30lsDyokKA=
 github.com/goccy/go-json v0.10.0/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -94,11 +95,13 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
@@ -150,8 +153,9 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
+github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
+github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
@@ -270,6 +274,7 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/repository/error.go
+++ b/repository/error.go
@@ -1,0 +1,10 @@
+package repository
+
+type BasicAuthError struct {
+	Reason string
+}
+
+func (e BasicAuthError) Error() (s string) {
+	s = "Auth failed. User or password not provided or invalid." + e.Reason
+	return
+}

--- a/repository/subversion.go
+++ b/repository/subversion.go
@@ -199,14 +199,17 @@ func (r *Subversion) writePassword(id *api.Identity) (err error) {
 		return
 	}
 
-	cmd := command.Command{Path: "/usr/bin/svn"}
+	cmd := command.Command{
+		Path:   "/usr/bin/svn",
+		Silent: true,
+	}
 	cmd.Options.Add("--non-interactive")
 	cmd.Options.Add("--username")
 	cmd.Options.Add(id.User)
 	cmd.Options.Add("--password")
 	cmd.Options.Add(id.Password)
 	cmd.Options.Add("info", r.URL().String())
-	err = cmd.RunSilent()
+	err = cmd.Run()
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Detected and report better errors by pattern matching in command output.  This provides the most benefit for commands like Maven the bury errors in a ton of output. Or, as in git output has cryptic output when using the trust store and credentials not associated.
Another part of this COULD be: To potentially taking another approach to Git and SVN credentials.  To pass them on the command line instead of the more complicated approach used currently.  The _masking_ is needed to support this.
For example (git):
```
https://github.com/konveyor/tackle-testapp.git
```
Would be:
```
https://user:password@github.com/konveyor/tackle-testapp.git
```
and masked when reported in Task.Activity as:
```
https://####:####@github.com/konveyor/tackle-testapp.git
```
This is simpler than setting up the git credentials store and would likely yield better errors.

---

This PR will support reporting better Auth errors but I'm not convinced it's worth it because with exception of the Git "Host not found .." cryptic error, all other errors are easily understood from the command output in the Task.Activity.