### PR TITLE
:bug: Report command path without arguments and stdout/stderr on error.

### DIFF
--- a/command/cmd.go
+++ b/command/cmd.go
@@ -7,9 +7,10 @@ package command
 import (
 	"context"
 	"fmt"
-	hub "github.com/konveyor/tackle2-hub/addon"
 	"os/exec"
 	"strings"
+
+	hub "github.com/konveyor/tackle2-hub/addon"
 )
 
 var (
@@ -60,7 +61,8 @@ func (r *Command) RunWith(ctx context.Context) (err error) {
 
 //
 // RunSilent executes the command.
-// Nothing reported in task Report.Activity.
+// On error: The command (without arguments) and output are
+// reported in task Report.Activity
 func (r *Command) RunSilent() (err error) {
 	err = r.RunSilentWith(context.TODO())
 	return
@@ -68,11 +70,19 @@ func (r *Command) RunSilent() (err error) {
 
 //
 // RunSilentWith executes the command with context.
-// Nothing reported in task Report.Activity.
+// On error: The command (without arguments) and output are
+// reported in task Report.Activity
 func (r *Command) RunSilentWith(ctx context.Context) (err error) {
 	cmd := exec.CommandContext(ctx, r.Path, r.Options...)
 	cmd.Dir = r.Dir
-	err = cmd.Run()
+	r.Output, err = cmd.CombinedOutput()
+	if err != nil {
+		addon.Activity(
+			"[CMD] %s failed: %s.\n%s",
+			r.Path,
+			err.Error(),
+			string(r.Output))
+	}
 	return
 }
 


### PR DESCRIPTION
Update RunSilent() to not fail silently.  Currently the returned error is reported as "exit code: 1" which isn't useful for troubleshooting.

The primary goal for RunSilent() is to quietly run the command.  One purpose is to prevent reporting arguments that contain credentials. This approach assumes that command don't output passwords to _stderr_.

Example:
```
errors:
    - severity: Error
      description: exit status 1
    - severity: Error
      description: 'Pod failed: Error'
activity:
    - Fetching application.
    - '[CMD] Running: /usr/bin/ssh-agent -a /tmp/agent.736692'
    - '[CMD] succeeded.'
    - '[SSH] Agent started.'
    - '[MVN] Using settings file(path=/home/jortel/tmp/addon/settings.xml).'
    - '[SVN] Cloning: http://3.19.255.219/repos/trunk'
    - '[SVN] Using credentials (id=3) SVN.'
    - '[CMD] /usr/bin/svn failed: exit status 1.'
    - '> svn: warning: W170000: URL ''http://3.19.255.219/repos/trunk'' non-existent in revision 3'
    - '> '
    - '> svn: E200009: Could not display info for all targets because some targets don''t exist'
    - '> '
```