### PR TITLE
:ghost: Better modeling of SCM and maven.

### DIFF
--- a/repository/factory.go
+++ b/repository/factory.go
@@ -25,27 +25,23 @@ func New(destDir string, remote *api.Repository, identities []api.Ref) (r SCM, e
 		if err != nil {
 			return
 		}
-		r = &Subversion{
-			Path:   destDir,
-			Remote: *remote,
-			Authenticated: Authenticated{
-				Identities: identities,
-				Insecure:   insecure,
-			},
-		}
+		svn := &Subversion{}
+		svn.Path = destDir
+		svn.Remote = *remote
+		svn.Identities = identities
+		svn.Insecure = insecure
+		r = svn
 	default:
 		insecure, err = addon.Setting.Bool("git.insecure.enabled")
 		if err != nil {
 			return
 		}
-		r = &Git{
-			Path:   destDir,
-			Remote: *remote,
-			Authenticated: Authenticated{
-				Identities: identities,
-				Insecure:   insecure,
-			},
-		}
+		git := &Git{}
+		git.Path = destDir
+		git.Remote = *remote
+		git.Identities = identities
+		git.Insecure = insecure
+		r = git
 	}
 	err = r.Validate()
 	return

--- a/repository/factory.go
+++ b/repository/factory.go
@@ -26,9 +26,9 @@ func New(destDir string, remote *api.Repository, identities []api.Ref) (r SCM, e
 			return
 		}
 		r = &Subversion{
-			Path: destDir,
-			Remote: Remote{
-				Repository: remote,
+			Path:   destDir,
+			Remote: *remote,
+			Authenticated: Authenticated{
 				Identities: identities,
 				Insecure:   insecure,
 			},
@@ -39,9 +39,9 @@ func New(destDir string, remote *api.Repository, identities []api.Ref) (r SCM, e
 			return
 		}
 		r = &Git{
-			Path: destDir,
-			Remote: Remote{
-				Repository: remote,
+			Path:   destDir,
+			Remote: *remote,
+			Authenticated: Authenticated{
 				Identities: identities,
 				Insecure:   insecure,
 			},
@@ -59,15 +59,14 @@ type SCM interface {
 	Commit(files []string, msg string) (err error)
 }
 
-// Remote repository.
-type Remote struct {
-	*api.Repository
+// Authenticated repository.
+type Authenticated struct {
 	Identities []api.Ref
 	Insecure   bool
 }
 
 // FindIdentity by kind.
-func (r *Remote) findIdentity(kind string) (matched *api.Identity, found bool, err error) {
+func (r *Authenticated) findIdentity(kind string) (matched *api.Identity, found bool, err error) {
 	for _, ref := range r.Identities {
 		identity, nErr := addon.Identity.Get(ref.ID)
 		if nErr != nil {

--- a/repository/git.go
+++ b/repository/git.go
@@ -17,8 +17,9 @@ import (
 
 // Git repository.
 type Git struct {
-	Remote
-	Path string
+	Authenticated
+	Remote api.Repository
+	Path   string
 }
 
 // Validate settings.

--- a/repository/maven.go
+++ b/repository/maven.go
@@ -21,7 +21,7 @@ const emptySettings = `
 
 // Maven repository.
 type Maven struct {
-	Remote
+	Authenticated
 	BinDir string
 	M2Dir  string
 }

--- a/repository/subversion.go
+++ b/repository/subversion.go
@@ -18,8 +18,9 @@ import (
 
 // Subversion repository.
 type Subversion struct {
-	Remote
-	Path string
+	Authenticated
+	Remote api.Repository
+	Path   string
 }
 
 // Validate settings.


### PR DESCRIPTION
The Remote currently contains a *api.Repository which is good for the SCM repositories but not relevant for Maven.  After this is removed, Remote only provides common _authentication_ attributes/operations.   This is the only thing SCM and Maven repositories have in common.