### PR TITLE
:ghost: Go 1.20.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PKGDIR = $(subst /...,,$(PKG))
 
 all: cmd
 
-fmt:
+fmt: $(GOIMPORTS)
 	$(GOIMPORTS) -w $(PKGDIR)
 
 vet:

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,25 @@
-GOBIN ?= ${GOPATH}/bin
+GOPATH ?= $(HOME)/go
+GOBIN ?= $(GOPATH)/bin
+GOIMPORTS = $(GOBIN)/goimports
+
+PKG = ./cmd/... \
+      ./command/... \
+      ./repository/... \
+      ./ssh/...
+
+PKGDIR = $(subst /...,,$(PKG))
 
 all: cmd
 
 fmt:
-	go fmt ./...
+	$(GOIMPORTS) -w $(PKGDIR)
 
 vet:
-	go vet ./...
+	go vet $(PKG)
 
 cmd: fmt vet
 	go build -ldflags="-w -s" -o bin/addon github.com/konveyor/tackle2-addon/cmd
+
+# Ensure goimports installed.
+$(GOIMPORTS):
+	go install golang.org/x/tools/cmd/goimports@latest

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,15 +1,13 @@
 package main
 
 import (
-	hub "github.com/konveyor/tackle2-hub/addon"
-)
-
-var (
-	addon = hub.Addon
+	"github.com/konveyor/tackle2-addon/command"
+	"github.com/konveyor/tackle2-addon/repository"
+	"github.com/konveyor/tackle2-addon/ssh"
 )
 
 func main() {
-	addon.Run(func() (err error) {
-		return
-	})
+	_ = command.New("")
+	_ = ssh.Agent{}
+	_, _ = repository.New("", nil, nil)
 }

--- a/command/cmd.go
+++ b/command/cmd.go
@@ -9,22 +9,21 @@ import (
 	"fmt"
 	"os/exec"
 
-	hub "github.com/konveyor/tackle2-hub/addon"
 	"path"
+
+	hub "github.com/konveyor/tackle2-hub/addon"
 )
 
 var (
 	addon = hub.Addon
 )
 
-//
 // New returns a command.
 func New(path string) (cmd *Command) {
 	cmd = &Command{Path: path}
 	return
 }
 
-//
 // Command execution.
 type Command struct {
 	Options  Options
@@ -34,7 +33,6 @@ type Command struct {
 	Writer   Writer
 }
 
-//
 // Run executes the command.
 // The command and output are both reported in
 // task Report.Activity.
@@ -43,7 +41,6 @@ func (r *Command) Run() (err error) {
 	return
 }
 
-//
 // RunWith executes the command with context.
 // The command and output are both reported in
 // task Report.Activity.
@@ -76,7 +73,6 @@ func (r *Command) RunWith(ctx context.Context) (err error) {
 	return
 }
 
-//
 // RunSilent executes the command.
 // On error: The command (without arguments) and output are
 // reported in task Report.Activity
@@ -86,24 +82,20 @@ func (r *Command) RunSilent() (err error) {
 	return
 }
 
-//
 // Output returns the command output.
 func (r *Command) Output() (b []byte) {
 	return r.Writer.buffer
 }
 
-//
 // Options are CLI options.
 type Options []string
 
-//
 // Add option.
 func (a *Options) Add(option string, s ...string) {
 	*a = append(*a, option)
 	*a = append(*a, s...)
 }
 
-//
 // Addf option.
 func (a *Options) Addf(option string, x ...interface{}) {
 	*a = append(*a, fmt.Sprintf(option, x...))

--- a/command/reporter.go
+++ b/command/reporter.go
@@ -2,10 +2,10 @@ package command
 
 import (
 	"strings"
+
 	"github.com/konveyor/tackle2-hub/api"
 )
 
-//
 // Verbosity.
 const (
 	// Disabled reports: NOTHING.
@@ -18,7 +18,6 @@ const (
 	LiveOutput = 1
 )
 
-//
 // Reporter activity reporter.
 type Reporter struct {
 	Verbosity int
@@ -26,7 +25,6 @@ type Reporter struct {
 	index     int
 }
 
-//
 // Run reports command started in task Report.Activity.
 func (r *Reporter) Run(path string, options Options) {
 	switch r.Verbosity {
@@ -41,7 +39,6 @@ func (r *Reporter) Run(path string, options Options) {
 	}
 }
 
-//
 // Succeeded reports command succeeded in task Report.Activity.
 func (r *Reporter) Succeeded(path string, output []byte) {
 	switch r.Verbosity {
@@ -59,7 +56,6 @@ func (r *Reporter) Succeeded(path string, output []byte) {
 	}
 }
 
-//
 // Error reports command failed in task Report.Activity.
 func (r *Reporter) Error(path string, err error, output []byte) {
 	if len(output) == 0 {
@@ -82,7 +78,6 @@ func (r *Reporter) Error(path string, err error, output []byte) {
 	}
 }
 
-//
 // Output reports command output.
 func (r *Reporter) Output(buffer []byte) (reported int) {
 	switch r.Verbosity {
@@ -103,7 +98,6 @@ func (r *Reporter) Output(buffer []byte) (reported int) {
 	return
 }
 
-//
 // append output.
 func (r *Reporter) append(batch []byte) {
 	if r.file == nil {

--- a/command/writer.go
+++ b/command/writer.go
@@ -13,7 +13,6 @@ const (
 	MinBackoff = Backoff
 )
 
-//
 // Writer records command output.
 type Writer struct {
 	reporter *Reporter
@@ -23,7 +22,6 @@ type Writer struct {
 	ended    chan any
 }
 
-//
 // Write command output.
 func (w *Writer) Write(p []byte) (n int, err error) {
 	n = len(p)
@@ -39,7 +37,6 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 	return
 }
 
-//
 // End of writing.
 func (w *Writer) End() {
 	if w.end == nil {
@@ -51,7 +48,6 @@ func (w *Writer) End() {
 	w.end = nil
 }
 
-//
 // report in task Report.Activity.
 // Rate limited.
 func (w *Writer) report() {
@@ -72,7 +68,6 @@ func (w *Writer) report() {
 	w.ended <- true
 }
 
-//
 // adjustBackoff adjust the backoff as needed.
 // incremented when output reported.
 // decremented when no outstanding output reported.

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/konveyor/tackle2-addon
 
-go 1.18
+go 1.20
 
 require (
 	github.com/clbanning/mxj v1.8.4
 	github.com/jortel/go-utils v0.1.2
-	github.com/konveyor/tackle2-hub v0.3.0-rc.2.0.20231219211826-f09d0b24c0e6
+	github.com/konveyor/tackle2-hub v0.3.0-rc.4.0.20240123170057-e18a6547d4af
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
-github.com/konveyor/tackle2-hub v0.3.0-rc.2.0.20231219211826-f09d0b24c0e6 h1:xPLwmNqA3QxVaqqnhF6v/T2ZMTCom2GcROD2BEJIHnQ=
-github.com/konveyor/tackle2-hub v0.3.0-rc.2.0.20231219211826-f09d0b24c0e6/go.mod h1:ZR4A0+Wp0H3QZkMohPnvZjxcolVORP3jdHV9Uwb/PoE=
+github.com/konveyor/tackle2-hub v0.3.0-rc.4.0.20240123170057-e18a6547d4af h1:Msqxh91TToZFmtbySbLShaUyVfqeq5SNWPQywOPOLHk=
+github.com/konveyor/tackle2-hub v0.3.0-rc.4.0.20240123170057-e18a6547d4af/go.mod h1:97Z3kWWmPERNl58XkpQkV/F+jnqNNDAVpL9m9XTZmdo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/repository/git.go
+++ b/repository/git.go
@@ -3,15 +3,16 @@ package repository
 import (
 	"errors"
 	"fmt"
+	urllib "net/url"
+	"os"
+	pathlib "path"
+	"strings"
+
 	liberr "github.com/jortel/go-utils/error"
 	"github.com/konveyor/tackle2-addon/command"
 	"github.com/konveyor/tackle2-addon/ssh"
 	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/nas"
-	urllib "net/url"
-	"os"
-	pathlib "path"
-	"strings"
 )
 
 // Git repository.

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -3,15 +3,16 @@ package ssh
 import (
 	"context"
 	"fmt"
+	"os"
+	pathlib "path"
+	"strings"
+	"time"
+
 	liberr "github.com/jortel/go-utils/error"
 	"github.com/konveyor/tackle2-addon/command"
 	hub "github.com/konveyor/tackle2-hub/addon"
 	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/nas"
-	"os"
-	pathlib "path"
-	"strings"
-	"time"
 )
 
 var (
@@ -28,12 +29,10 @@ func init() {
 
 }
 
-//
 // Agent agent.
 type Agent struct {
 }
 
-//
 // Start the ssh-agent.
 func (r *Agent) Start() (err error) {
 	pid := os.Getpid()
@@ -55,7 +54,6 @@ func (r *Agent) Start() (err error) {
 	return
 }
 
-//
 // Add ssh key.
 func (r *Agent) Add(id *api.Identity, host string) (err error) {
 	if id.Key == "" {
@@ -132,7 +130,6 @@ func (r *Agent) Add(id *api.Identity, host string) (err error) {
 	return
 }
 
-//
 // Ensure key formatting.
 func (r *Agent) format(in string) (out string) {
 	if in != "" {
@@ -141,7 +138,6 @@ func (r *Agent) format(in string) (out string) {
 	return
 }
 
-//
 // writeAsk writes script that returns the key password.
 func (r *Agent) writeAsk(id *api.Identity) (err error) {
 	path := "/tmp/ask.sh"


### PR DESCRIPTION
upgrade Go 1.20.
Replaces gofmt with goimports. Documentation claims it performs the same formatting plus manages/orders imports.
Added missing packages in Makefile.
Updated the go.mod and ran go mod tidy.

Updated cmd/main.go to include sub-packages so they're compiled.

closes: #44 

NOT FOR 0.3.