### PR TITLE
:sparkles: Local config and creds.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,5 +9,5 @@ import (
 func main() {
 	_ = command.New("")
 	_ = ssh.Agent{}
-	_, _ = repository.New("", nil, nil)
+	_, _ = repository.New("", nil)
 }

--- a/command/cmd.go
+++ b/command/cmd.go
@@ -29,6 +29,7 @@ type Command struct {
 	Options  Options
 	Path     string
 	Dir      string
+	Env      []string
 	Reporter Reporter
 	Writer   Writer
 }
@@ -63,6 +64,7 @@ func (r *Command) RunWith(ctx context.Context) (err error) {
 	}()
 	cmd := exec.CommandContext(ctx, r.Path, r.Options...)
 	cmd.Dir = r.Dir
+	cmd.Env = r.Env
 	cmd.Stdout = &r.Writer
 	cmd.Stderr = &r.Writer
 	err = cmd.Start()

--- a/repository/factory.go
+++ b/repository/factory.go
@@ -8,13 +8,11 @@ import (
 )
 
 var (
-	addon   = hub.Addon
-	HomeDir = ""
-	Dir     = ""
+	addon = hub.Addon
+	Dir   = ""
 )
 
 func init() {
-	HomeDir, _ = os.UserHomeDir()
 	Dir, _ = os.Getwd()
 }
 

--- a/repository/factory.go
+++ b/repository/factory.go
@@ -20,7 +20,12 @@ func init() {
 type Remote = api.Repository
 
 // New SCM repository factory.
-func New(destDir string, remote *Remote) (r SCM, err error) {
+// Options:
+// - *api.Ref
+// - api.Ref
+// - *api.Identity
+// - api.Identity
+func New(destDir string, remote *Remote, option ...any) (r SCM, err error) {
 	var insecure bool
 	switch remote.Kind {
 	case "subversion":
@@ -47,6 +52,12 @@ func New(destDir string, remote *Remote) (r SCM, err error) {
 	err = r.Validate()
 	if err != nil {
 		return
+	}
+	for _, opt := range option {
+		err = r.Use(opt)
+		if err != nil {
+			return
+		}
 	}
 	return
 }

--- a/repository/factory.go
+++ b/repository/factory.go
@@ -10,10 +10,12 @@ import (
 var (
 	addon   = hub.Addon
 	HomeDir = ""
+	Dir     = ""
 )
 
 func init() {
 	HomeDir, _ = os.UserHomeDir()
+	Dir, _ = os.Getwd()
 }
 
 type Remote = api.Repository

--- a/repository/git.go
+++ b/repository/git.go
@@ -44,6 +44,7 @@ func (r *Git) Validate() (err error) {
 // Fetch clones the repository.
 func (r *Git) Fetch() (err error) {
 	url := r.URL()
+	addon.Activity("[GIT] Home (directory): %s", r.home())
 	addon.Activity("[GIT] Cloning: %s", url.String())
 	_ = nas.RmDir(r.Path)
 	if r.Identity.ID != 0 {

--- a/repository/git.go
+++ b/repository/git.go
@@ -168,10 +168,6 @@ func (r *Git) URL() (u GitURL) {
 // writeConfig writes config file.
 func (r *Git) writeConfig() (err error) {
 	path := pathlib.Join(Dir, ".gitconfig")
-	found, err := nas.Exists(path)
-	if found || err != nil {
-		return
-	}
 	f, err := os.Create(path)
 	if err != nil {
 		err = liberr.Wrap(
@@ -180,7 +176,6 @@ func (r *Git) writeConfig() (err error) {
 			path)
 		return
 	}
-
 	proxy, err := r.proxy()
 	if err != nil {
 		return
@@ -189,7 +184,9 @@ func (r *Git) writeConfig() (err error) {
 	s += "name = Konveyor Dev\n"
 	s += "email = konveyor-dev@googlegroups.com\n"
 	s += "[credential]\n"
-	s += "helper = store\n"
+	s += "helper = store --file="
+	s += pathlib.Join(Dir, ".git-credentials")
+	s += "\n"
 	s += "[http]\n"
 	s += fmt.Sprintf("sslVerify = %t\n", !r.Insecure)
 	if proxy != "" {
@@ -213,21 +210,7 @@ func (r *Git) writeCreds(id *api.Identity) (err error) {
 		return
 	}
 	path := pathlib.Join(Dir, ".git-credentials")
-	found, err := nas.Exists(path)
-	if found || err != nil {
-		return
-	}
 	f, err := os.Create(path)
-	if err != nil {
-		err = liberr.Wrap(
-			err,
-			"path",
-			path)
-		return
-	}
-	_, err = f.Write([]byte(
-		fmt.Sprintf("[credential]\n  helper = store --file=%s",
-			path)))
 	if err != nil {
 		err = liberr.Wrap(
 			err,

--- a/repository/git.go
+++ b/repository/git.go
@@ -114,7 +114,7 @@ func (r *Git) Commit(files []string, msg string) (err error) {
 	cmd.Dir = r.Path
 	cmd.Options.Add("commit")
 	cmd.Options.Add("--allow-empty")
-	cmd.Options.Add("--m", msg)
+	cmd.Options.Add("-m", msg)
 	err = cmd.Run()
 	if err != nil {
 		return err

--- a/repository/git.go
+++ b/repository/git.go
@@ -340,7 +340,7 @@ func (r *Git) setEnv(cmd *command.Command) {
 		"GIT_TERMINAL_PROMPT=0",
 		fmt.Sprintf(
 			"GIT_CONFIG_GLOBAL=%s",
-			pathlib.Join(HomeDir, ".gitconfig")))
+			pathlib.Join(Dir, ".gitconfig")))
 }
 
 // GitURL git clone URL.

--- a/repository/git.go
+++ b/repository/git.go
@@ -155,7 +155,7 @@ func (r *Git) URL() (u GitURL) {
 
 // writeConfig writes config file.
 func (r *Git) writeConfig() (err error) {
-	path := pathlib.Join(HomeDir, ".gitconfig")
+	path := pathlib.Join(Dir, ".gitconfig")
 	f, err := os.Create(path)
 	if err != nil {
 		err = liberr.Wrap(
@@ -197,7 +197,7 @@ func (r *Git) writeCreds() (err error) {
 	if r.Identity.User == "" || r.Identity.Password == "" {
 		return
 	}
-	path := pathlib.Join(HomeDir, ".git-credentials")
+	path := pathlib.Join(Dir, ".git-credentials")
 	f, err := os.Create(path)
 	if err != nil {
 		err = liberr.Wrap(

--- a/repository/git.go
+++ b/repository/git.go
@@ -113,7 +113,8 @@ func (r *Git) Commit(files []string, msg string) (err error) {
 	cmd := r.git()
 	cmd.Dir = r.Path
 	cmd.Options.Add("commit")
-	cmd.Options.Add("--message", msg)
+	cmd.Options.Add("--allow-empty")
+	cmd.Options.Add("--m", msg)
 	err = cmd.Run()
 	if err != nil {
 		return err

--- a/repository/git.go
+++ b/repository/git.go
@@ -137,11 +137,23 @@ func (r *Git) Head() (commit string, err error) {
 	return
 }
 
+// git returns git command.
+func (r *Git) git() (cmd *command.Command) {
+	cmd = command.New("/usr/bin/git")
+	cmd.Env = append(
+		os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_TRACE_SETUP=1",
+		"GIT_TRACE=1",
+		"HOME="+Dir)
+	return
+}
+
 // push changes to remote.
 func (r *Git) push() (err error) {
 	cmd := r.git()
 	cmd.Dir = r.Path
-	cmd.Options.Add("push", "--set-upstream", "origin", r.Remote.Branch)
+	cmd.Options.Add("push", "origin", "HEAD")
 	err = cmd.Run()
 	return
 }
@@ -173,7 +185,7 @@ func (r *Git) writeConfig() (err error) {
 	s += "email = konveyor-dev@googlegroups.com\n"
 	s += "[credential]\n"
 	s += "helper = store --file="
-	s += pathlib.Join(HomeDir, ".git-credentials")
+	s += pathlib.Join(Dir, ".git-credentials")
 	s += "\n"
 	s += "[http]\n"
 	s += fmt.Sprintf("sslVerify = %t\n", !r.Insecure)
@@ -301,13 +313,6 @@ func (r *Git) checkout() (err error) {
 	cmd := r.git()
 	cmd.Options.Add("checkout", branch)
 	err = cmd.Run()
-	return
-}
-
-// git returns git command.
-func (r *Git) git() (cmd *command.Command) {
-	cmd = command.New("/usr/bin/git")
-	cmd.Env = append(os.Environ(), "HOME="+Dir)
 	return
 }
 

--- a/repository/git.go
+++ b/repository/git.go
@@ -52,7 +52,7 @@ func (r *Git) Fetch() (err error) {
 			r.Identity.ID,
 			r.Identity.Name)
 	}
-	err = nas.MkDir(r.home(), 0644)
+	err = nas.MkDir(r.home(), 0755)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return

--- a/repository/maven.go
+++ b/repository/maven.go
@@ -43,18 +43,16 @@ func (r *Maven) CreateSettingsFile() (path string, err error) {
 			path)
 		return
 	}
-	defer f.Close()
-	id, found, err := r.findIdentity("maven")
-	if err != nil {
-		return
-	}
+	defer func() {
+		_ = f.Close()
+	}()
 	var settingsXML mxj.Map
-	if found {
+	if r.Identity.ID != 0 {
 		addon.Activity(
 			"[MVN] Using credentials (id=%d) %s.",
-			id.ID,
-			id.Name)
-		settingsXML, err = mxj.NewMapXml([]byte(id.Settings))
+			r.Identity.ID,
+			r.Identity.Name)
+		settingsXML, err = mxj.NewMapXml([]byte(r.Identity.Settings))
 		if err != nil {
 			err = liberr.Wrap(err)
 			return

--- a/repository/subversion.go
+++ b/repository/subversion.go
@@ -210,10 +210,6 @@ func (r *Subversion) writeConfig() (err error) {
 		r.home(),
 		".subversion",
 		"servers")
-	found, err := nas.Exists(path)
-	if found || err != nil {
-		return
-	}
 	err = nas.MkDir(pathlib.Dir(path), 0755)
 	if err != nil {
 		return
@@ -247,11 +243,7 @@ func (r *Subversion) writePassword() (err error) {
 	if r.Identity.User == "" || r.Identity.Password == "" {
 		return
 	}
-	cmd := command.New("/usr/bin/svn")
-	cmd.Options.Add("--non-interactive")
-	if r.Insecure {
-		cmd.Options.Add("--trust-server-cert")
-	}
+	cmd := r.svn()
 	cmd.Options.Add("--username")
 	cmd.Options.Add(r.Identity.User)
 	cmd.Options.Add("--password")

--- a/repository/subversion.go
+++ b/repository/subversion.go
@@ -255,7 +255,7 @@ func (r *Subversion) writePassword() (err error) {
 		return
 	}
 	dir := pathlib.Join(
-		HomeDir,
+		Dir,
 		".subversion",
 		"auth",
 		"svn.simple")

--- a/repository/subversion.go
+++ b/repository/subversion.go
@@ -142,6 +142,7 @@ func (r *Subversion) URL() (u *SvnURL) {
 // svn returns an svn command.
 func (r *Subversion) svn() (cmd *command.Command) {
 	cmd = command.New("/usr/bin/svn")
+	cmd.Env = append(os.Environ(), "HOME="+Dir)
 	cmd.Options.Add("--non-interactive")
 	if r.Insecure {
 		cmd.Options.Add("--trust-server-cert")

--- a/repository/subversion.go
+++ b/repository/subversion.go
@@ -199,7 +199,7 @@ func (r *Subversion) addFiles(files []string) (err error) {
 // writeConfig writes configuration file.
 func (r *Subversion) writeConfig() (err error) {
 	path := pathlib.Join(
-		HomeDir,
+		Dir,
 		".subversion",
 		"servers")
 	found, err := nas.Exists(path)

--- a/repository/subversion.go
+++ b/repository/subversion.go
@@ -49,6 +49,7 @@ func (r *Subversion) Validate() (err error) {
 // Fetch clones the repository.
 func (r *Subversion) Fetch() (err error) {
 	u := r.URL()
+	addon.Activity("[SVN] Home (directory): %s", r.home())
 	addon.Activity("[SVN] Cloning: %s", u.String())
 	if r.Identity.ID != 0 {
 		addon.Activity(

--- a/repository/subversion.go
+++ b/repository/subversion.go
@@ -56,7 +56,7 @@ func (r *Subversion) Fetch() (err error) {
 			r.Identity.ID,
 			r.Identity.Name)
 	}
-	err = nas.MkDir(r.home(), 0644)
+	err = nas.MkDir(r.home(), 0755)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -33,6 +33,7 @@ type Agent struct {
 // Start the ssh-agent.
 func (r *Agent) Start() (err error) {
 	pid := os.Getpid()
+	addon.Activity("[SSH] Home (directory): %s", Dir)
 	socket := fmt.Sprintf("/tmp/agent.%d", pid)
 	cmd := command.New("/usr/bin/ssh-agent")
 	cmd.Env = append(os.Environ(), "HOME="+Dir)

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -23,9 +23,7 @@ var (
 
 func init() {
 	Dir, _ = os.Getwd()
-	SSHDir = pathlib.Join(
-		Dir,
-		".ssh")
+	SSHDir = pathlib.Join(Dir, ".ssh")
 }
 
 // Agent agent.

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -16,17 +16,16 @@ import (
 )
 
 var (
-	addon   = hub.Addon
-	HomeDir = ""
-	SSHDir  = ""
+	addon  = hub.Addon
+	Dir    = ""
+	SSHDir = ""
 )
 
 func init() {
-	HomeDir, _ = os.UserHomeDir()
+	Dir, _ = os.Getwd()
 	SSHDir = pathlib.Join(
-		HomeDir,
+		Dir,
 		".ssh")
-
 }
 
 // Agent agent.
@@ -38,6 +37,7 @@ func (r *Agent) Start() (err error) {
 	pid := os.Getpid()
 	socket := fmt.Sprintf("/tmp/agent.%d", pid)
 	cmd := command.New("/usr/bin/ssh-agent")
+	cmd.Env = append(os.Environ(), "HOME="+Dir)
 	cmd.Options.Add("-a", socket)
 	err = cmd.Run()
 	if err != nil {
@@ -96,6 +96,7 @@ func (r *Agent) Add(id *api.Identity, host string) (err error) {
 		time.Second)
 	defer fn()
 	cmd := command.New("/usr/bin/ssh-add")
+	cmd.Env = append(os.Environ(), "HOME="+Dir)
 	cmd.Options.Add(path)
 	err = cmd.RunWith(ctx)
 	if err != nil {

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -64,10 +64,6 @@ func (r *Agent) Add(id *api.Identity, host string) (err error) {
 	path := pathlib.Join(
 		SSHDir,
 		suffix)
-	found, err := nas.Exists(path)
-	if found || err != nil {
-		return
-	}
 	f, err := os.OpenFile(
 		path,
 		os.O_RDWR|os.O_CREATE,


### PR DESCRIPTION
### problem
This is needed to support working with multiple repositories simultaneously. 

### solution
The configuration and credentials cannot be written into the _HOME_ directory.  Further, each instance of
the SCM needs to have their own.
Add command.Command.Env support.
Update ssh, git, subversion to write credentials and run with HOME=_dir_ where _dir_ is specific to each instance. 
The ssh.Agent writes keys in .ssh/ with identity ID prefix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for customizing environment variables when running commands.

* **Refactor**
  * Simplified and unified identity and credential handling for Git, Maven, and Subversion repositories.
  * Repository-specific configuration and credential files are now stored in hashed directories under the current working directory.
  * Improved flexibility in repository creation and configuration options with a new option mechanism.
  * Updated SSH agent handling and environment setup for enhanced reliability and consistent environment variables.
  * Enhanced Git command execution with improved environment isolation and updated command options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->