### PR TITLE
:bug: Fix trace in commit.

### DIFF
--- a/repository/git.go
+++ b/repository/git.go
@@ -152,8 +152,6 @@ func (r *Git) git() (cmd *command.Command) {
 	cmd.Env = append(
 		os.Environ(),
 		"GIT_TERMINAL_PROMPT=0",
-		"GIT_TRACE_SETUP=1",
-		"GIT_TRACE=1",
 		"HOME="+r.home())
 	return
 }


### PR DESCRIPTION
closes #74 

An alternative would be for Head() to return the last line in the output.
Thoughts?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Suppressed Git trace output during operations to prevent unexpected verbose logging in normal use.
  - Maintains non-interactive behavior for Git commands, avoiding prompt interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->